### PR TITLE
Add missing semicolons after macro calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix: Missing semicolons caused compilation errors when using 3 or more values in a chain. This is now fixed (https://github.com/schneems/magic_migrate/pull/7)
+
 ## 0.2.0 - 2024/05/12
 
 - Introduce `try_migrate_toml_chain!`, `migrate_deserializer_chain!` and `try_migrate_deserializer_chain!` macros (https://github.com/schneems/magic_migrate/pull/5)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub trait Migrate: From<Self::From> + Any + DeserializeOwned + Debug {
 /// // support `From<Infallible>`
 /// impl From<Infallible> for PersonMigrationError {
 ///     fn from(_value: Infallible) -> Self {
-///       unreachable!()
+///       unreachable!();
 ///     }
 /// }
 ///
@@ -335,8 +335,8 @@ macro_rules! migrate_link {
         $crate::migrate_link!($a, $b);
 
         // Link B => C, and the rest
-        $crate::migrate_link!($b, $($rest),*)
-    )
+        $crate::migrate_link!($b, $($rest),*);
+    );
 }
 
 /// Links each struct passed in to each other to build a [`Migrate`] link chain.
@@ -361,7 +361,7 @@ macro_rules! migrate_link {
 /// # struct UserV2;
 /// # impl From<UserV1> for UserV2 {
 /// #   fn from(value: UserV1) -> Self {
-/// #     unimplemented!()
+/// #     unimplemented!();
 /// #   }
 /// # }
 /// #
@@ -369,7 +369,7 @@ macro_rules! migrate_link {
 /// # struct UserV3;
 /// # impl From<UserV2> for UserV3 {
 /// #   fn from(value: UserV2) -> Self {
-/// #     unimplemented!()
+/// #     unimplemented!();
 /// #   }
 /// # }
 ///
@@ -397,7 +397,7 @@ macro_rules! migrate_toml_chain {
             deserializer: toml::Deserializer::new,
             chain: [$a, $($rest),+]
         );
-    )
+    );
 }
 
 /// Macro for linking structs together in an infallible [`TryMigrate`] migration chain
@@ -434,8 +434,8 @@ macro_rules! try_migrate_link {
         $crate::try_migrate_link!($a, $b);
 
         // Link B => C, and the rest
-        $crate::try_migrate_link!($b, $($rest),*)
-    )
+        $crate::try_migrate_link!($b, $($rest),*);
+    );
 }
 
 /// A macro to help define [`TryMigrate`] based migrations
@@ -521,7 +521,7 @@ macro_rules! try_migrate_link {
 macro_rules! try_migrate_toml_chain {
     // Base case
     (error: $err:ident, chain: [$a:ident] $(,)?) => {
-        $crate::try_migrate_deserializer_chain!(error: $err, deserializer: toml::Deserializer::new, chain: [$a])
+        $crate::try_migrate_deserializer_chain!(error: $err, deserializer: toml::Deserializer::new, chain: [$a]);
     };
     // Position variant
     (chain: [$a:ident], error: $err:ident $(,)?) => {
@@ -537,7 +537,7 @@ macro_rules! try_migrate_toml_chain {
     );
     // Position variant
     (chain: [$a:ident, $($rest:ident),+], error: $err:ident $(,)?) => (
-        $crate::try_migrate_toml_chain!(error: $err, chain: [$a, $($rest),+])
+        $crate::try_migrate_toml_chain!(error: $err, chain: [$a, $($rest),+]);
     );
 }
 
@@ -724,7 +724,7 @@ macro_rules! try_migrate_deserializer_chain {
         }
         impl From<Infallible> for $err {
             fn from(_value: Infallible) -> Self {
-                unreachable!()
+                unreachable!();
             }
         }
     };


### PR DESCRIPTION
Otherwise I was getting this error:

```
error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> /Users/rschneeman/.cargo/registry/src/index.crates.io-6f17d22bba15001f/magic_migrate-0.2.0/src/lib.rs:437:34
    |
419 |   macro_rules! try_migrate_link {
    |   ----------------------------- in this expansion of `$crate::try_migrate_link!` (#3)
...
437 |           $crate::try_migrate_link!($b, $($rest),*)
    |                                    ^^^^^^^^^^^^^^^^
...
714 |   macro_rules! try_migrate_deserializer_chain {
    |   -------------------------------------------
    |   |
    |   in this expansion of `try_migrate_deserializer_chain!` (#1)
    |   in this expansion of `$crate::try_migrate_deserializer_chain!` (#2)
...
737 |           $crate::try_migrate_link!($a, $($rest),+);
    |           ----------------------------------------- in this macro invocation (#3)
...
764 |           $crate::try_migrate_deserializer_chain!(error: $err, deserializer: $deser, chain: [$a, $($rest),+]);
    |           --------------------------------------------------------------------------------------------------- in this macro invocation (#2)
    |
   ::: buildpacks/ruby/src/layers/bundle_install_layer.rs:120:1
    |
120 | / try_migrate_deserializer_chain!(
121 | |     chain: [MetadataV1, MetadataV2, MetadataV3],
122 | |     error: MetadataMigrateError,
123 | |     deserializer: toml::Deserializer::new,
124 | | );
    | |_- in this macro invocation (#1)

error: could not compile `heroku-ruby-buildpack` (bin "heroku-ruby-buildpack") due to 1 previous error
⛄️ 3.3.1 🚀 /Users/rschneeman/Documents/projects/work/buildpacks-ruby/buildpacks/ruby (schneems/pub-traits)
$ RUSTFLAGS="-Zmacro-backtrace" cargo build 
   Compiling heroku-ruby-buildpack v0.0.0 (/Users/rschneeman/Documents/projects/work/buildpacks-ruby/buildpacks/ruby)
error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> /Users/rschneeman/.cargo/registry/src/index.crates.io-6f17d22bba15001f/magic_migrate-0.2.0/src/lib.rs:437:34
    |
419 |   macro_rules! try_migrate_link {
    |   ----------------------------- in this expansion of `$crate::try_migrate_link!` (#3)
...
437 |           $crate::try_migrate_link!($b, $($rest),*)
    |                                    ^^^^^^^^^^^^^^^^
...
714 |   macro_rules! try_migrate_deserializer_chain {
    |   -------------------------------------------
    |   |
    |   in this expansion of `try_migrate_deserializer_chain!` (#1)
    |   in this expansion of `$crate::try_migrate_deserializer_chain!` (#2)
...
737 |           $crate::try_migrate_link!($a, $($rest),+);
    |           ----------------------------------------- in this macro invocation (#3)
...
764 |           $crate::try_migrate_deserializer_chain!(error: $err, deserializer: $deser, chain: [$a, $($rest),+]);
    |           --------------------------------------------------------------------------------------------------- in this macro invocation (#2)
    |
   ::: buildpacks/ruby/src/layers/bundle_install_layer.rs:120:1
    |
120 | / try_migrate_deserializer_chain!(
121 | |     chain: [MetadataV1, MetadataV2, MetadataV3],
122 | |     error: MetadataMigrateError,
123 | |     deserializer: toml::Deserializer::new,
124 | | );
    | |_- in this macro invocation (#1)
```

From this code:

```
try_migrate_deserializer_chain!(
    chain: [MetadataV1, MetadataV2, MetadataV3],
    error: MetadataMigrateError,
    deserializer: toml::Deserializer::new,
);
```

Presumably because I was using 3 values instead of just 2.

I tried to induce the same error here https://github.com/schneems/magic_migrate/pull/8 but I'm unable to do so with the same test suite.