### PR TITLE
Add a test that should fail but doesn't

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,6 +657,13 @@ macro_rules! migrate_deserializer_chain {
 ///     updated_at: DateTime<Utc>
 /// }
 ///
+/// #[derive(Deserialize, Serialize, Debug)]
+/// #[serde(deny_unknown_fields)]
+/// struct PersonV3 {
+///     full_name: String,
+///     updated_at: DateTime<Utc>
+/// }
+///
 /// // First define how to map from one struct to another
 /// impl TryFrom<PersonV1> for PersonV2 {
 ///     type Error = NotRichard;
@@ -670,6 +677,17 @@ macro_rules! migrate_deserializer_chain {
 ///         } else {
 ///             Err(NotRichard { name: value.name.clone() })
 ///         }
+///     }
+/// }
+///
+/// impl TryFrom<PersonV2> for PersonV3 {
+///     type Error = NotRichard;
+///
+///     fn try_from(value: PersonV2) -> Result<Self, NotRichard> {
+///        Ok(PersonV3 {
+///           full_name: value.name.clone(),
+///           updated_at: value.updated_at
+///        })
 ///     }
 /// }
 ///
@@ -690,9 +708,9 @@ macro_rules! migrate_deserializer_chain {
 /// }
 ///
 /// try_migrate_deserializer_chain!(
-///     deserializer: toml::Deserializer::new,
+///     chain: [PersonV1, PersonV2, PersonV3],
 ///     error: PersonMigrationError,
-///     chain: [PersonV1, PersonV2],
+///     deserializer: toml::Deserializer::new,
 /// );
 ///
 /// // Now, given a serialized struct


### PR DESCRIPTION
Edit: Here's the code that produces the original error https://github.com/heroku/buildpacks-ruby/pull/369

There's a bug in the macros where this code is missing a semicolon:

```
        // Link B => C, and the rest
        $crate::try_migrate_link!($b, $($rest),*)
```

It should be triggered by the code in this test but it's not.

It mimics this code from the Ruby buildpack:

```
try_migrate_deserializer_chain!(
    chain: [MetadataV1, MetadataV2, MetadataV3],
    error: MetadataMigrateError,
    deserializer: toml::Deserializer::new,
);
```

Which triggers this error (backtrace courtesy of nightly) `RUSTFLAGS="-Zmacro-backtrace" cargo build`

```
$ RUSTFLAGS="-Zmacro-backtrace" cargo build 
   Compiling heroku-ruby-buildpack v0.0.0 (/Users/rschneeman/Documents/projects/work/buildpacks-ruby/buildpacks/ruby)
error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> /Users/rschneeman/.cargo/registry/src/index.crates.io-6f17d22bba15001f/magic_migrate-0.2.0/src/lib.rs:437:34
    |
419 |   macro_rules! try_migrate_link {
    |   ----------------------------- in this expansion of `$crate::try_migrate_link!` (#3)
...
437 |           $crate::try_migrate_link!($b, $($rest),*)
    |                                    ^^^^^^^^^^^^^^^^
...
714 |   macro_rules! try_migrate_deserializer_chain {
    |   -------------------------------------------
    |   |
    |   in this expansion of `try_migrate_deserializer_chain!` (#1)
    |   in this expansion of `$crate::try_migrate_deserializer_chain!` (#2)
...
737 |           $crate::try_migrate_link!($a, $($rest),+);
    |           ----------------------------------------- in this macro invocation (#3)
...
764 |           $crate::try_migrate_deserializer_chain!(error: $err, deserializer: $deser, chain: [$a, $($rest),+]);
    |           --------------------------------------------------------------------------------------------------- in this macro invocation (#2)
    |
   ::: buildpacks/ruby/src/layers/bundle_install_layer.rs:120:1
    |
120 | / try_migrate_deserializer_chain!(
121 | |     chain: [MetadataV1, MetadataV2, MetadataV3],
122 | |     error: MetadataMigrateError,
123 | |     deserializer: toml::Deserializer::new,
124 | | );
    | |_- in this macro invocation (#1)
```

However, the current test compiles and runs just fine and I don't know why.