### PR TITLE
Require Errors to be Debug + Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Change: `TryMigrate::Error` must now be `Display` + `Debug` ()
+
 ## 0.2.1 - 2024/12/12
 
 - Fix: Missing semicolons caused compilation errors when using 3 or more values in a chain. This is now fixed (https://github.com/schneems/magic_migrate/pull/7)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ version = "0.2.1"
 dependencies = [
  "chrono",
  "serde",
+ "thiserror",
  "toml",
 ]
 
@@ -163,9 +164,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -210,13 +211,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ serde = "1"
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 serde = {version = "1", features = ["derive"]}
+thiserror = { version = "2.0.8" }
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ impl From<NotRichard> for PersonMigrationError {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
 enum PersonMigrationError {
+    #[error("Not Richard {0:?}")]
     NotRichard(NotRichard),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 use serde::de::DeserializeOwned;
 use serde::Deserializer;
 use std::any::{Any, TypeId};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 /// Use the [`Migrate`] trait when structs can be infallibly migrated
 /// from one version to the next. Use the [`TryMigrate`] trait when
@@ -192,8 +192,9 @@ pub trait Migrate: From<Self::From> + Any + DeserializeOwned + Debug {
 /// //
 /// // Because the migration can fail we need to resolve
 /// // error types.
-/// #[derive(Debug, Eq, PartialEq)]
+/// #[derive(Debug, thiserror::Error, Eq, PartialEq)]
 /// enum PersonMigrationError {
+///     #[error("Not Richard {0:?}")]
 ///     NotRichard(NotRichard),
 /// }
 ///
@@ -267,7 +268,9 @@ pub trait TryMigrate: TryFrom<Self::TryFrom> + Any + DeserializeOwned + Debug {
     fn deserializer<'de>(input: &str) -> impl Deserializer<'de>;
 
     type Error: From<<Self as TryFrom<<Self as TryMigrate>::TryFrom>>::Error>
-        + From<<<Self as TryMigrate>::TryFrom as TryMigrate>::Error>;
+        + From<<<Self as TryMigrate>::TryFrom as TryMigrate>::Error>
+        + Display
+        + Debug;
 
     #[must_use]
     fn try_from_str_migrations(input: &str) -> Option<Result<Self, <Self as TryMigrate>::Error>> {
@@ -492,8 +495,9 @@ macro_rules! try_migrate_link {
 ///     }
 /// }
 ///
-/// #[derive(Debug, Eq, PartialEq)]
+/// #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 /// enum PersonMigrationError {
+///     #[error("Not Richard {0:?}")]
 ///     NotRichard(NotRichard),
 /// }
 ///
@@ -684,8 +688,9 @@ macro_rules! migrate_deserializer_chain {
 ///     }
 /// }
 ///
-/// #[derive(Debug, Eq, PartialEq)]
+/// #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 /// enum PersonMigrationError {
+///     #[error("Not Richard {0:?}")]
 ///     NotRichard(NotRichard),
 /// }
 ///


### PR DESCRIPTION
One goal of this library is to provide a clean interface for other libraries. Errors need to be visible to be useful, it's common that they are required to be Debug + Display. Without these requirements here, they must be added to downstream libraries APIs which is gnarly. For example:

```rust
pub(crate) fn cached_layer_write_metadata<M, B>(
    layer_name: LayerName,
    context: &BuildContext<B>,
    metadata: &'_ M,
) -> libcnb::Result<LayerRef<B, Meta<M>, Meta<M>>, B::Error>
where
    B: libcnb::Buildpack,
    M: CacheDiff + TryMigrate + Serialize
    <M as TryMigrate>::Error: std::fmt::Display, // <=== HERE
{
    // ...
}
```

With this change applied it should allow applications to remove that extra qualification:

```rust
pub(crate) fn cached_layer_write_metadata<M, B>(
    layer_name: LayerName,
    context: &BuildContext<B>,
    metadata: &'_ M,
) -> libcnb::Result<LayerRef<B, Meta<M>, Meta<M>>, B::Error>
where
    B: libcnb::Buildpack,
    M: CacheDiff + TryMigrate + Serialize
    // Much cleaner now!
{
    // ...
}
```

This is an API change, so it's a major version rev. Though most (if not all) consumers would be using this with errors that are already Debug + Display.